### PR TITLE
Remove unused `jsaddle-warp` dependency

### DIFF
--- a/diagrams-reflex.cabal
+++ b/diagrams-reflex.cabal
@@ -30,7 +30,6 @@ Library
                      , diagrams-core
                      , diagrams-lib
                      , jsaddle
-                     , jsaddle-warp
                      , lens
                      , mtl
                      , reflex


### PR DESCRIPTION
This change is all that's needed to get the library running with the latest Reflex and GHC, compiling to Wasm, so that's cool.

I was going to request an accompanying Hackage release, but I think we'll actually want to battle-test things a bit first. It's very odd that this dependency was added unconditionally in the first place, and from glancing at the last few PRs merged, there are some other changes which, frankly, I'm inclined to suggest reverting.